### PR TITLE
fix: add boundary check for empty content_anchors (Issue #30)

### DIFF
--- a/scripts/fetch_tweet.py
+++ b/scripts/fetch_tweet.py
@@ -583,6 +583,10 @@ def parse_timeline_snapshot(snapshot: str, limit: int = 20) -> List[Dict]:
     # the main tweet's text content. So if we see text content (not just
     # author/handle/time) between anchor N-1 and anchor N, then N is a quote.
 
+    # 如果没有找到任何内容锚点，直接返回空列表
+    if not content_anchors:
+        return tweets
+
     primary_indices = [0]  # first anchor is always primary
     quoted_set = set()     # indices into content_anchors that are quotes
 


### PR DESCRIPTION
## 修复内容

- 在  函数中添加边界检查
- 当  为空时直接返回空列表，避免 IndexError

## 问题根因

当 Nitter 列表页面没有解析到任何有效的推文锚点时， 为空，但代码仍然假设至少有一个元素，导致  索引越界。

## 测试

```bash
python3 scripts/fetch_tweet.py --list "1868493605888413851" --limit 3
```

现在返回空列表而不是崩溃（返回0条推文是因为 Nitter 限流，不是代码问题）。