### PR TITLE
fix: security hardening — 命令注入防护 + 输入校验 + 死代码修复

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
-data/x-mentions-nitter-cache.json
+data/
+logs/

--- a/scripts/camofox_client.py
+++ b/scripts/camofox_client.py
@@ -7,6 +7,7 @@ Used by fetch_tweet.py and fetch_china.py.
 """
 
 import json
+import secrets
 import sys
 import time
 import urllib.request
@@ -27,6 +28,9 @@ def check_camofox(port: int = 9377) -> bool:
 
 def camofox_open_tab(url: str, session_key: str, port: int = 9377) -> Optional[str]:
     """Open a new Camofox tab; return tabId or None."""
+    if not url.startswith(('http://', 'https://')):
+        print(f"[Camofox] rejected non-HTTP URL: {url[:60]}", file=sys.stderr)
+        return None
     try:
         payload = json.dumps({
             "userId": "x-tweet-fetcher",
@@ -103,13 +107,13 @@ def camofox_search(query: str, num: int = 10, lang: str = "zh-CN", engine: str =
     
     if engine == "duckduckgo":
         search_url = f"https://duckduckgo.com/?q={encoded}&kl={lang}&t=h_"
-        snapshot = camofox_fetch_page(search_url, f"ddg-{int(time.time())}", wait=5, port=port)
+        snapshot = camofox_fetch_page(search_url, f"ddg-{secrets.token_hex(8)}", wait=5, port=port)
         if not snapshot:
             return []
         return _parse_duckduckgo_results(snapshot, num)
     else:
         search_url = f"https://www.google.com/search?q={encoded}&hl={lang}&num={num}"
-        snapshot = camofox_fetch_page(search_url, f"search-{int(time.time())}", wait=4, port=port)
+        snapshot = camofox_fetch_page(search_url, f"search-{secrets.token_hex(8)}", wait=4, port=port)
         if not snapshot:
             return []
         return _parse_google_results(snapshot)

--- a/scripts/fetch_china.py
+++ b/scripts/fetch_china.py
@@ -1286,12 +1286,13 @@ class XiaohongshuParser(PlatformParser):
     def _fetch_via_router(self, url: str) -> Optional[str]:
         """Fetch page HTML via router's home IP (bypasses geo-block)."""
         import subprocess
+        import shlex
         cmd_queue = "/root/router-agent/cmd-queue"
         cmd_output = "/root/router-agent/cmd-output"
         
         # Write curl command to router queue
         curl_cmd = (
-            f'curl -sL "{url}" '
+            f'curl -sL {shlex.quote(url)} '
             f'-H "User-Agent: Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) '
             f'AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1" '
             f'-H "Accept: text/html" '
@@ -1301,7 +1302,7 @@ class XiaohongshuParser(PlatformParser):
         
         try:
             # Clear old output
-            subprocess.run(['bash', '-c', f'> {cmd_output}'], timeout=3)
+            open(cmd_output, 'w').close()
             # Queue command
             with open(cmd_queue, 'w') as f:
                 f.write(curl_cmd)

--- a/scripts/sogou_wechat.py
+++ b/scripts/sogou_wechat.py
@@ -22,6 +22,7 @@ from urllib.parse import quote
 import re
 import json
 import argparse
+import shlex
 import sys
 import os
 import html as html_lib
@@ -38,6 +39,11 @@ def sogou_wechat_search_via_router(keyword, max_results=10):
     queue_file = os.environ.get("ROUTER_CMD_QUEUE", "/root/router-agent/cmd-queue")
     result_file = os.environ.get("ROUTER_CMD_RESULT", "/root/router-agent/cmd-result")
     output_file = os.environ.get("ROUTER_CMD_OUTPUT", "/root/router-agent/cmd-output")
+
+    for path_var in (queue_file, result_file, output_file):
+        if not os.path.isabs(path_var) or '..' in path_var:
+            print(f"Invalid router path: {path_var}", file=sys.stderr)
+            return sogou_wechat_search(keyword, max_results)
     
     # Mark current result file position
     try:
@@ -49,7 +55,8 @@ def sogou_wechat_search_via_router(keyword, max_results=10):
     
     # Queue the curl command — router will fetch raw HTML
     encoded_kw = quote(keyword)
-    cmd = f'curl -s "https://weixin.sogou.com/weixin?type=2&query={encoded_kw}" -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"'
+    search_url = f'https://weixin.sogou.com/weixin?type=2&query={encoded_kw}'
+    cmd = f'curl -s {shlex.quote(search_url)} -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"'
     
     with open(queue_file, 'w') as f:
         f.write(cmd)
@@ -106,13 +113,20 @@ def _parse_sogou_html(text, max_results=10):
             article_url = 'https://weixin.sogou.com' + article_url
         results.append({'title': title, 'url': article_url, 'author': author, 'snippet': snippet, 'date': date})
     return results
+
+
+def sogou_wechat_search_via_ssh(keyword, max_results=10, ssh_host=None):
     """Search Sogou WeChat via SSH proxy to avoid IP bans.
-    
+
     Requires: SOGOU_SSH_HOST env var or ssh_host param (e.g. user@host).
     """
     host = ssh_host or os.environ.get("SOGOU_SSH_HOST")
     if not host:
         print("SOGOU_SSH_HOST not set, falling back to direct", file=sys.stderr)
+        return sogou_wechat_search(keyword, max_results)
+
+    if not re.match(r'^[\w.-]+@[\w.-]+$', host):
+        print(f"Invalid SSH host format: {host}", file=sys.stderr)
         return sogou_wechat_search(keyword, max_results)
 
     script = f'''
@@ -147,12 +161,12 @@ print(json.dumps(results, ensure_ascii=False))
         with tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False) as f:
             f.write(script)
             local_path = f.name
-        
+
         remote_path = "/tmp/_sogou_search.py"
         subprocess.run(["scp", "-o", "ConnectTimeout=5", "-q", local_path, f"{host}:{remote_path}"],
                        capture_output=True, timeout=10)
         os.unlink(local_path)
-        
+
         result = subprocess.run(
             ["ssh", "-o", "ConnectTimeout=5", host, "python3", remote_path],
             capture_output=True, text=True, timeout=30

--- a/scripts/x_discover.py
+++ b/scripts/x_discover.py
@@ -53,7 +53,7 @@ def search_web(query, max_results=5, timelimit=None):
 
 
 def url_hash(url):
-    return hashlib.md5(url.encode()).hexdigest()[:12]
+    return hashlib.sha256(url.encode()).hexdigest()[:12]
 
 
 def load_cache(cache_file):

--- a/scripts/x_mentions_nitter.py
+++ b/scripts/x_mentions_nitter.py
@@ -17,12 +17,13 @@ from datetime import datetime
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'skills/our/x-tweet-fetcher/scripts'))
 from camofox_client import camofox_fetch_page
 
-USERNAME = "YuLin807"
+USERNAME = os.environ.get("NITTER_USERNAME", "YuLin807")
+NITTER_HOST = os.environ.get("NITTER_HOST", "nitter.net")
 CACHE_DIR = os.path.join(os.path.dirname(__file__), '..', 'data')
 os.makedirs(CACHE_DIR, exist_ok=True)
 CACHE_FILE = os.path.join(CACHE_DIR, "x-mentions-nitter-cache.json")
 RESULT_FILE = os.path.join(CACHE_DIR, "x-mentions-nitter-latest.json")
-NITTER_URL = f"https://nitter.net/search?f=tweets&q=%40{USERNAME}"
+NITTER_URL = f"https://{NITTER_HOST}/search?f=tweets&q=%40{USERNAME}"
 
 def parse_mentions(snapshot):
     """从 Nitter 快照中解析 mentions"""


### PR DESCRIPTION
## 安全审查修复

对代码进行安全审查后发现的问题修复。

### 修复内容

**P0 — 命令注入**
- `fetch_china.py`: `subprocess.run(['bash', '-c', f'> {cmd_output}'])` → `open(cmd_output, 'w').close()`
- `fetch_china.py`: curl 命令中 URL 参数使用 `shlex.quote()` 防护
- `sogou_wechat.py`: router curl 命令中 URL 使用 `shlex.quote()` 防护

**BUG — 死代码**
- `sogou_wechat.py`: `_parse_sogou_html` 的 `return results` 后面的 `sogou_wechat_search_via_ssh` 函数体缺少 `def` 声明，导致整个函数是死代码。已修复为独立顶层函数。

**P1 — 输入校验**
- `sogou_wechat.py`: SSH host 格式校验 (`re.match(r'^[\w.-]+@[\w.-]+$', host)`)
- `sogou_wechat.py`: Router 路径校验（绝对路径 + 无 `..`）
- `camofox_client.py`: URL scheme 白名单（仅 `http://` / `https://`）

**P2 — 安全加固**
- `camofox_client.py`: session key 从 `int(time.time())` 改为 `secrets.token_hex(8)`
- `x_mentions_nitter.py`: 硬编码 USERNAME/NITTER_HOST 改为环境变量可配置
- `.gitignore`: 补充 `data/` 和 `logs/` 目录

**P3 — Lint 友好**
- `x_discover.py`: 缓存哈希 `hashlib.md5` → `hashlib.sha256`

### 测试

- 所有修改文件通过 `py_compile` 语法检查
- 关键模块 import 验证通过
- 安全修复 grep 验证通过（无 `bash -c`，有 `shlex.quote`，有 `secrets`）