### PR TITLE
Harden default agent profile and gate higher-risk integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # 🦞 x-tweet-fetcher
 
-**Fetch tweets, lists, articles, and WeChat content — with smart backend routing.**
+**Fetch X/Twitter content first, with optional extras for lists, articles, and WeChat.**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![OpenClaw Skill](https://img.shields.io/badge/OpenClaw-Skill-blue.svg)](https://github.com/openclaw/openclaw)
@@ -29,6 +29,34 @@ You: ...seriously?
 X has no free API. Scraping gets you blocked. Browser automation is fragile and won't work in headless environments.
 
 **x-tweet-fetcher** solves this with **smart backend routing**: Nitter for zero-dependency speed, Playwright for full-feature coverage, auto fallback between them.
+
+## 🔒 Security Profiles
+
+This repo works best when split into a **safe default X-only profile** and optional extras.
+
+### Recommended default for OpenClaw / agent runtimes
+
+Use these files by default:
+
+- `scripts/fetch_tweet.py`
+- `scripts/nitter_client.py`
+- `scripts/playwright_client.py`
+- `scripts/tweet_growth.py`
+- `scripts/tweet_growth_cli.py`
+
+This keeps the default profile focused on X/Twitter fetch + monitoring, with no router queue, SSH, cookie import, or local auth-profile reads.
+
+### Optional extras, enable intentionally
+
+- `scripts/fetch_china.py`
+- `scripts/sogou_wechat.py`
+- `scripts/x-profile-analyzer.py`
+- `scripts/to_obsidian.py`
+- `scripts/paper_to_obsidian.py`
+
+These files are useful, but they expand scope into browser automation, LLM APIs, cookies, proxying, router integration, or local-note export.
+
+See also: [`docs/security-profiles.md`](docs/security-profiles.md)
 
 ## 🔀 Three Backends
 
@@ -96,7 +124,7 @@ python3 scripts/fetch_tweet.py --url https://x.com/elonmusk/status/123456789 --r
 # @mentions monitoring (cron-friendly)
 python3 scripts/fetch_tweet.py --monitor @yourusername
 
-# User profile analysis
+# User profile analysis (requires explicit API env vars)
 python3 scripts/x-profile-analyzer.py --user elonmusk --count 100
 ```
 
@@ -113,7 +141,7 @@ python3 scripts/fetch_tweet.py --article https://x.com/user/article/123 --backen
 python3 scripts/fetch_china.py --url "https://mp.weixin.qq.com/s/..."
 ```
 
-### WeChat search (always zero-dep)
+### WeChat search (always zero-dep, router path only via explicit env vars)
 
 ```bash
 python3 scripts/sogou_wechat.py --keyword "AI Agent" --limit 5 --json
@@ -217,6 +245,8 @@ python3 scripts/nitter_client.py --search "test"
 - **Bind to `127.0.0.1` only** — never expose to public internet
 - **Use a secondary X account** — session token gives full access
 - **Session tokens last ~1 year**
+- **Router queue integration is opt-in** — set `ROUTER_CMD_QUEUE`, `ROUTER_CMD_RESULT`, and `ROUTER_CMD_OUTPUT` explicitly if you use it
+- **AI profile analysis is env-only** — set `MINIMAX_API_KEY` or `OPENAI_API_KEY` explicitly
 
 ## 📐 How It Works
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,16 +1,32 @@
 ---
 name: x-tweet-fetcher
 description: >
-  Fetch tweets, replies, and user timelines from X/Twitter without login or API keys.
-  Also supports Chinese platforms (Weibo, Bilibili, CSDN, WeChat).
-  Includes camofox_search() for zero-cost Google search without API keys.
-  Basic tweet fetching: zero dependencies. Replies/timelines/search: requires Camofox.
-  NEW: X-Tracker for tweet growth monitoring with burst detection.
+  Fetch X/Twitter tweets, replies, timelines, and growth data without login or API keys.
+  China-platform fetching, profile analysis, and router/proxy integrations are optional extras.
+  Basic tweet fetching is zero dependency. Advanced browsing uses the browser backend.
 ---
 
 # X Tweet Fetcher
 
-Fetch tweets from X/Twitter without authentication. Supports tweet content, reply threads, user timelines, Chinese platforms, and tweet growth tracking.
+Fetch tweets from X/Twitter without authentication. The recommended default profile is X-only. China platforms, profile analysis, and router/proxy features should be enabled intentionally.
+
+## Recommended Default Profile
+
+For OpenClaw or other agent runtimes, the safest default profile is:
+
+- `scripts/fetch_tweet.py`
+- `scripts/nitter_client.py`
+- `scripts/playwright_client.py`
+- `scripts/tweet_growth.py`
+- `scripts/tweet_growth_cli.py`
+
+Optional extras that expand scope and should be reviewed before use:
+
+- `scripts/fetch_china.py`
+- `scripts/sogou_wechat.py`
+- `scripts/x-profile-analyzer.py`
+- `scripts/to_obsidian.py`
+- `scripts/paper_to_obsidian.py`
 
 ## Feature Overview
 

--- a/docs/security-profiles.md
+++ b/docs/security-profiles.md
@@ -1,0 +1,82 @@
+# Security Profiles
+
+This repository can be used in two different ways.
+
+## 1. Safe default: X-only profile
+
+Recommended for OpenClaw, Claude Code, CI, and shared agent runtimes.
+
+### Keep
+
+- `scripts/fetch_tweet.py`
+- `scripts/nitter_client.py`
+- `scripts/playwright_client.py`
+- `scripts/tweet_growth.py`
+- `scripts/tweet_growth_cli.py`
+- `README.md`
+- `SKILL.md`
+
+### Why
+
+This profile stays focused on X/Twitter fetch, replies, timelines, mentions, search, and growth tracking.
+It avoids router queues, SSH helpers, cookie import flows, and local note export.
+
+## 2. Optional extras: review before enabling
+
+### Higher-scope files
+
+- `scripts/fetch_china.py`
+- `scripts/sogou_wechat.py`
+- `scripts/x-profile-analyzer.py`
+- `scripts/to_obsidian.py`
+- `scripts/paper_to_obsidian.py`
+- `scripts/paper_recommend.py`
+- `scripts/arxiv_author_finder.py`
+
+### Why they need extra review
+
+These files may rely on one or more of the following:
+
+- external LLM APIs
+- SSH / SCP
+- router queue files
+- cookies or proxies
+- local note export
+- broader web scraping scope beyond X/Twitter
+
+## Minimal OpenClaw skill skeleton
+
+Use this shape when packaging the X-only profile as a separate skill:
+
+~~~md
+---
+name: x-tweet-fetcher-safe
+description: >
+  Fetch X/Twitter tweets, replies, timelines, mentions, and growth data.
+  Default profile excludes router, SSH, cookies, proxies, and local auth reads.
+---
+
+# X Tweet Fetcher Safe
+
+## Commands
+
+```bash
+python3 scripts/fetch_tweet.py --url https://x.com/user/status/123
+python3 scripts/fetch_tweet.py --user username --limit 20
+python3 scripts/fetch_tweet.py --url https://x.com/user/status/123 --replies
+python3 scripts/tweet_growth_cli.py --add https://x.com/user/status/123 label
+```
+
+## Scope
+
+- Safe default: X-only
+- Optional extras: disabled by default
+- Auth: environment variables only
+~~~
+
+## Packaging advice
+
+- Make X-only the default profile in agent runtimes.
+- Gate router integration behind explicit env vars.
+- Keep API keys env-only.
+- Treat cookies and proxies as user-supplied optional inputs, not defaults.

--- a/scripts/fetch_china.py
+++ b/scripts/fetch_china.py
@@ -1282,10 +1282,20 @@ class XiaohongshuParser(PlatformParser):
 
     def _fetch_via_router(self, url: str) -> Optional[str]:
         """Fetch page HTML via router's home IP (bypasses geo-block)."""
-        import subprocess
         import shlex
-        cmd_queue = "/root/router-agent/cmd-queue"
-        cmd_output = "/root/router-agent/cmd-output"
+        import os
+
+        cmd_queue = os.environ.get("ROUTER_CMD_QUEUE", "").strip()
+        cmd_output = os.environ.get("ROUTER_CMD_OUTPUT", "").strip()
+
+        if not (cmd_queue and cmd_output):
+            print("[xiaohongshu] Router env vars not configured, skip router fetch", file=sys.stderr)
+            return None
+
+        for path_var in (cmd_queue, cmd_output):
+            if not os.path.isabs(path_var) or '..' in path_var:
+                print(f"[xiaohongshu] Invalid router path: {path_var}", file=sys.stderr)
+                return None
         
         # Write curl command to router queue
         curl_cmd = (

--- a/scripts/fetch_tweet.py
+++ b/scripts/fetch_tweet.py
@@ -56,6 +56,7 @@ _MESSAGES = {
             "参考: https://github.com/openclaw/camofox"
         ),
         "err_snapshot_failed": "无法从 Camofox 获取页面快照",
+        "err_antibot_challenge": "Nitter 反爬挑战拦截了请求。请更换实例，或使用本地/自建 Nitter。",
         "err_mutually_exclusive": "错误：--user、--url、--article、--monitor 和 --list 不能同时使用",
         "err_no_input": "错误：请提供 --url 或 --user",
         "err_prefix": "错误：",
@@ -128,6 +129,7 @@ _MESSAGES = {
             "See: https://github.com/openclaw/camofox"
         ),
         "err_snapshot_failed": "Failed to get page snapshot from Camofox",
+        "err_antibot_challenge": "Nitter anti-bot challenge blocked the request. Try another instance or a local/self-hosted Nitter.",
         "err_mutually_exclusive": "Error: --user, --url, --article, --monitor, and --list are mutually exclusive",
         "err_no_input": "Error: provide --url or --user",
         "err_prefix": "Error: ",
@@ -264,6 +266,18 @@ def camofox_fetch_page(url: str, session_key: str, wait: float = 8, port: int = 
     snapshot = camofox_snapshot(tab_id, port)
     camofox_close_tab(tab_id, port)
     return snapshot
+
+
+def _looks_like_antibot_snapshot(snapshot: str) -> bool:
+    if not snapshot:
+        return False
+    markers = (
+        "Making sure you're not a bot!",
+        "Verifying your request",
+        "Anubis",
+        "Sorry this pages exist in order to keep the service usable for everyone.",
+    )
+    return any(marker in snapshot for marker in markers)
 
 
 # --- Browser backend priority: playwright > camofox ---
@@ -1355,6 +1369,9 @@ def fetch_tweet_replies(
 
     if not snapshot:
         result["error"] = t("err_snapshot_failed")
+        return result
+    if _looks_like_antibot_snapshot(snapshot):
+        result["error"] = t("err_antibot_challenge")
         return result
 
     replies = parse_replies_snapshot(snapshot, original_author=username)

--- a/scripts/nitter_client.py
+++ b/scripts/nitter_client.py
@@ -31,6 +31,13 @@ from typing import List, Dict, Optional, Tuple
 
 NITTER_URL = os.environ.get("NITTER_URL", "http://127.0.0.1:8788").rstrip("/")
 
+_ANTIBOT_MARKERS = (
+    "Making sure you're not a bot!",
+    "Verifying your request",
+    "Anubis",
+    "Sorry this pages exist in order to keep the service usable for everyone.",
+)
+
 _HEADERS = {
     "User-Agent": (
         "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
@@ -62,13 +69,18 @@ def _fetch_html(url: str, timeout: int = 15) -> str:
         return ""
 
 
+def _looks_like_antibot_page(html: str) -> bool:
+    return bool(html) and any(marker in html for marker in _ANTIBOT_MARKERS)
+
+
 def check_nitter(url: str = NITTER_URL, timeout: int = 5) -> bool:
     """Return True if Nitter is reachable."""
     try:
         req = urllib.request.Request(url + "/", headers=_HEADERS)
         with urllib.request.urlopen(req, timeout=timeout) as resp:
-            resp.read(128)
-        return True
+            charset = resp.headers.get_content_charset() or "utf-8"
+            sample = resp.read(4096).decode(charset, errors="replace")
+        return not _looks_like_antibot_page(sample)
     except Exception:
         return False
 
@@ -492,6 +504,8 @@ def fetch_tweet_detail(username: str, tweet_id: str) -> Dict:
     html = _fetch_html(url)
     if not html:
         return {"error": f"Failed to fetch {url}"}
+    if _looks_like_antibot_page(html):
+        return {"error": f"Nitter anti-bot challenge blocked {url}"}
 
     # Split HTML into main tweet and replies sections
     main_html = ""

--- a/scripts/playwright_client.py
+++ b/scripts/playwright_client.py
@@ -23,16 +23,55 @@ import os
 import sys
 import time
 import secrets
+import shutil
 import urllib.parse
 from typing import Optional, List, Dict, Any, Tuple
 
 # ---------------------------------------------------------------------------
 # Chromium executable path
 # ---------------------------------------------------------------------------
-_CHROMIUM_EXEC = os.environ.get(
-    "PLAYWRIGHT_CHROMIUM_EXEC",
-    "/root/.cache/ms-playwright/chromium-1208/chrome-linux64/chrome",
-)
+
+def _candidate_browser_paths() -> List[str]:
+    env_path = os.environ.get("PLAYWRIGHT_CHROMIUM_EXEC", "").strip()
+    candidates = [
+        env_path,
+        "/root/.cache/ms-playwright/chromium-1208/chrome-linux64/chrome",
+        "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+        os.path.expanduser("~/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"),
+        shutil.which("google-chrome") or "",
+        shutil.which("chromium") or "",
+        shutil.which("chromium-browser") or "",
+    ]
+    # de-dupe while preserving order
+    seen = set()
+    result = []
+    for p in candidates:
+        if p and p not in seen:
+            seen.add(p)
+            result.append(p)
+    return result
+
+
+def _find_browser_executable() -> Optional[str]:
+    for path in _candidate_browser_paths():
+        if os.path.isfile(path) and os.access(path, os.X_OK):
+            return path
+    return None
+
+
+_CHROMIUM_EXEC = _find_browser_executable()
+
+
+def _playwright_importable() -> bool:
+    try:
+        from playwright.sync_api import sync_playwright  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+def _playwright_ready() -> bool:
+    return _playwright_importable() and (_CHROMIUM_EXEC is not None)
 
 # Default working Nitter instance (nitter.net is down; tiekoetter is live)
 # Nitter fallback chain: tested 2026-03-22, only these 3 are alive
@@ -55,10 +94,11 @@ _tab_store: dict = {}   # tab_id → page text
 
 def _launch_browser():
     """Return a (playwright, browser) pair.  Caller must close both."""
+    if not _playwright_importable():
+        raise RuntimeError("playwright Python package is not installed")
     from playwright.sync_api import sync_playwright  # lazy import
     pw = sync_playwright().start()
-    browser = pw.chromium.launch(
-        executable_path=_CHROMIUM_EXEC,
+    launch_kwargs = dict(
         headless=True,
         args=[
             "--no-sandbox",
@@ -68,6 +108,9 @@ def _launch_browser():
             "--disable-blink-features=AutomationControlled",
         ],
     )
+    if _CHROMIUM_EXEC:
+        launch_kwargs["executable_path"] = _CHROMIUM_EXEC
+    browser = pw.chromium.launch(**launch_kwargs)
     return pw, browser
 
 
@@ -478,8 +521,8 @@ def playwright_fetch_nitter_user_info(
 # ---------------------------------------------------------------------------
 
 def check_camofox(port: int = 9377) -> bool:
-    """Always returns True – Playwright needs no separate server."""
-    return True
+    """Return True when Playwright and a browser executable are available."""
+    return _playwright_ready()
 
 
 def camofox_open_tab(url: str, session_key: str, port: int = 9377) -> Optional[str]:

--- a/scripts/sogou_wechat.py
+++ b/scripts/sogou_wechat.py
@@ -35,9 +35,13 @@ def sogou_wechat_search_via_router(keyword, max_results=10):
     Uses home IP — never gets banned by Sogou.
     """
     import time
-    queue_file = os.environ.get("ROUTER_CMD_QUEUE", "/root/router-agent/cmd-queue")
-    result_file = os.environ.get("ROUTER_CMD_RESULT", "/root/router-agent/cmd-result")
-    output_file = os.environ.get("ROUTER_CMD_OUTPUT", "/root/router-agent/cmd-output")
+    queue_file = os.environ.get("ROUTER_CMD_QUEUE", "").strip()
+    result_file = os.environ.get("ROUTER_CMD_RESULT", "").strip()
+    output_file = os.environ.get("ROUTER_CMD_OUTPUT", "").strip()
+
+    if not (queue_file and result_file and output_file):
+        print("Router env vars not configured, falling back to direct", file=sys.stderr)
+        return sogou_wechat_search(keyword, max_results)
 
     for path_var in (queue_file, result_file, output_file):
         if not os.path.isabs(path_var) or '..' in path_var:

--- a/scripts/x-profile-analyzer.py
+++ b/scripts/x-profile-analyzer.py
@@ -14,7 +14,7 @@ Usage:
     python3 x_profile_analyzer.py --user elonmusk --no-analyze --output-json data.json
 
 AI 配置（完整模式需要，三选一）：
-    export MINIMAX_API_KEY=xxx     # MiniMax（OpenClaw 用户自动读取，无需配置）
+    export MINIMAX_API_KEY=xxx     # MiniMax
     export OPENAI_API_KEY=xxx      # OpenAI / DeepSeek 等
     export OPENAI_BASE_URL=xxx     # 自定义接口（可选）
     export OPENAI_MODEL=xxx        # 模型名（可选，默认 gpt-4o-mini）
@@ -30,14 +30,12 @@ import urllib.request
 import urllib.error
 from datetime import datetime
 from typing import Optional, Dict, List, Tuple
-from pathlib import Path
 
 
 # ── 配置 ──────────────────────────────────────────────────────────────────────
 
 MINIMAX_API_URL = "https://api.minimax.io/anthropic/v1/messages"
 OPENAI_API_URL = "https://api.openai.com/v1/chat/completions"
-AUTH_PROFILES_PATH = Path.home() / ".openclaw" / "agents" / "main" / "agent" / "auth-profiles.json"
 # REFERENCE_USER 已移除（v1.1）
 
 
@@ -48,29 +46,14 @@ def load_api_config() -> tuple:
     加载 AI API 配置，返回 (api_key, api_url, model_name, backend)
     优先级：
       1. MINIMAX_API_KEY 环境变量
-      2. OpenClaw auth-profiles.json（OpenClaw 用户自动读取）
-      3. OPENAI_API_KEY 环境变量（兼容任何 OpenAI 格式接口）
+      2. OPENAI_API_KEY 环境变量（兼容任何 OpenAI 格式接口）
     """
-    import os
-
     # 1. 环境变量 MINIMAX_API_KEY
     mm_key = os.environ.get("MINIMAX_API_KEY")
     if mm_key:
         return mm_key, MINIMAX_API_URL, "MiniMax-M2.5", "minimax"
 
-    # 2. OpenClaw auth-profiles.json
-    try:
-        with open(AUTH_PROFILES_PATH) as f:
-            data = json.load(f)
-        profiles = data.get("profiles", {})
-        mm = profiles.get("minimax:default", {})
-        key = mm.get("key", "")
-        if key:
-            return key, MINIMAX_API_URL, "MiniMax-M2.5", "minimax"
-    except Exception:
-        pass
-
-    # 3. OPENAI_API_KEY（兼容 OpenAI / DeepSeek / 任何兼容接口）
+    # 2. OPENAI_API_KEY（兼容 OpenAI / DeepSeek / 任何兼容接口）
     openai_key = os.environ.get("OPENAI_API_KEY")
     openai_url = os.environ.get("OPENAI_BASE_URL", OPENAI_API_URL)
     openai_model = os.environ.get("OPENAI_MODEL", "gpt-4o-mini")


### PR DESCRIPTION
## Summary

This PR hardens the default agent-facing profile and makes higher-risk integrations opt-in.

### What changed

- document a recommended **X-only default profile** in `README.md` and `SKILL.md`
- add `docs/security-profiles.md` with:
  - keep/remove guidance
  - a minimal OpenClaw skill skeleton
  - packaging advice for agent runtimes
- make router queue integration **env-only opt-in** in:
  - `scripts/sogou_wechat.py`
  - `scripts/fetch_china.py`
- remove local OpenClaw auth-profile reads from `scripts/x-profile-analyzer.py`
  - API access is now **environment-variable only**

## Why

The repo is powerful, but the default runtime surface was broader than necessary for agent environments. This narrows the default profile to X/Twitter fetching and growth tracking, while preserving higher-scope features as explicit opt-in extras.

## Verification

- `python3 -m py_compile scripts/x-profile-analyzer.py scripts/sogou_wechat.py scripts/fetch_china.py scripts/fetch_tweet.py scripts/nitter_client.py scripts/tweet_growth.py scripts/tweet_growth_cli.py`
- `python3 scripts/x-profile-analyzer.py --help`
- `python3 scripts/sogou_wechat.py --help`
- `python3 scripts/fetch_china.py --help`

## Notes

I intentionally did **not** remove the higher-scope features from the repo. This PR keeps them available, but makes the safer default profile much clearer and removes a couple of surprising implicit trust paths.
