### PR TITLE
[codex] Fix Nitter session docs and Playwright Chromium path

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Use a **secondary account** (not your main).
 3. Create `sessions.jsonl`:
 
 ```json
-{"name":"myaccount","auth_token":"YOUR_AUTH_TOKEN","ct0":"YOUR_CT0"}
+{"kind":"cookie","username":"myaccount","authToken":"YOUR_AUTH_TOKEN","ct0":"YOUR_CT0"}
 ```
 
 #### 4. Configure

--- a/scripts/playwright_client.py
+++ b/scripts/playwright_client.py
@@ -29,10 +29,23 @@ from typing import Optional, List, Dict, Any, Tuple
 # ---------------------------------------------------------------------------
 # Chromium executable path
 # ---------------------------------------------------------------------------
-_CHROMIUM_EXEC = os.environ.get(
-    "PLAYWRIGHT_CHROMIUM_EXEC",
-    "/root/.cache/ms-playwright/chromium-1208/chrome-linux64/chrome",
-)
+_CHROMIUM_EXEC_ENV = "PLAYWRIGHT_CHROMIUM_EXEC"
+
+
+def _resolve_chromium_executable(browser_type) -> Optional[str]:
+    """Return a Chromium executable path, preferring a valid env override."""
+    env_path = os.environ.get(_CHROMIUM_EXEC_ENV)
+    if env_path:
+        if os.path.exists(env_path):
+            return env_path
+        print(
+            f"[playwright_client] {_CHROMIUM_EXEC_ENV} does not exist: {env_path}; "
+            "using Playwright bundled Chromium",
+            file=sys.stderr,
+        )
+
+    executable_path = getattr(browser_type, "executable_path", None)
+    return executable_path if executable_path and os.path.exists(executable_path) else None
 
 # Default working Nitter instance (nitter.net is down; tiekoetter is live)
 # Nitter fallback chain: tested 2026-03-22, only these 3 are alive
@@ -57,17 +70,20 @@ def _launch_browser():
     """Return a (playwright, browser) pair.  Caller must close both."""
     from playwright.sync_api import sync_playwright  # lazy import
     pw = sync_playwright().start()
-    browser = pw.chromium.launch(
-        executable_path=_CHROMIUM_EXEC,
-        headless=True,
-        args=[
+    launch_options = {
+        "headless": True,
+        "args": [
             "--no-sandbox",
             "--disable-setuid-sandbox",
             "--disable-dev-shm-usage",
             "--disable-gpu",
             "--disable-blink-features=AutomationControlled",
         ],
-    )
+    }
+    executable_path = _resolve_chromium_executable(pw.chromium)
+    if executable_path:
+        launch_options["executable_path"] = executable_path
+    browser = pw.chromium.launch(**launch_options)
     return pw, browser
 
 


### PR DESCRIPTION
## Summary
- Update the README `sessions.jsonl` example to the Nitter cookie schema: `kind`, `username`, `authToken`, and `ct0`.
- Remove the hardcoded Linux Playwright Chromium fallback from `scripts/playwright_client.py`.
- Resolve Chromium executable paths at launch time by preferring a valid `PLAYWRIGHT_CHROMIUM_EXEC`, then Playwright's bundled Chromium path, otherwise letting Playwright use its default behavior.

## Validation
- `python3 -m py_compile scripts/playwright_client.py scripts/fetch_tweet.py scripts/nitter_client.py`
- `git diff --check`
- Static dry-run for `_resolve_chromium_executable` confirming an invalid Linux path env override no longer forces `/root/.cache/ms-playwright/.../chrome-linux64/chrome`.
- `rg -n "/root/.cache/ms-playwright|chromium-1208|chrome-linux64" scripts/playwright_client.py README.md` returned no matches.

Refs #60